### PR TITLE
Carthage Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ xcuserdata/
 
 # System
 .DS_Store
+
+# Carthage
+Carthage/


### PR DESCRIPTION
This prevents an issue where any git repo that included SQLite.swift as a submodule using Carthage would be marked dirty. This happened because SQLite.swift builds itself using Carthage, and the resulting build artefacts are untracked by git resulting in the submodule being marked dirty. We can avoid that by just ignoring the _Carthage_ directory.
